### PR TITLE
Fixed casting type error in legacy.php

### DIFF
--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -493,7 +493,7 @@ abstract class JModelLegacy extends JObject
 
 			$rowArray = JArrayHelper::fromObject(json_decode($historyTable->version_data));
 
-			$typeId = JTable::getInstance('Contenttype')->getTypeId($this->typeAlias);
+			$typeId = (int) JTable::getInstance('Contenttype')->getTypeId($this->typeAlias);
 
 			if ($historyTable->ucm_type_id != $typeId)
 			{


### PR DESCRIPTION
I've faced with problem when tried to restore revision in article manager.
I'm getting error: JLIB_APPLICATION_ERROR_HISTORY_ID_MISMATCH="Error restoring item version from history."
To fix it variable $typeId should be converted to integer because comparison with 0 with Null causes this error.
